### PR TITLE
do not pass directories to flog_ruby

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -170,6 +170,7 @@ class Flog < MethodBasedSexpProcessor
 
   def flog(*files)
     files.each do |file|
+      next if File.directory? file
       next unless file == '-' or File.readable? file
 
       ruby = file == '-' ? $stdin.read : File.binread(file)


### PR DESCRIPTION
stumbled across error exposed by metric-fu, as flog seems to just skip unreadable files, same should be done for directories, even if they are readable.

******* STARTING METRIC flog
/my-project-root/vendor/bundle/ruby/2.3.0/gems/flog-4.4.0/lib/flog.rb:175:in `binread': Is a directory @ io_fread - base (Errno::EISDIR)
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/flog-4.4.0/lib/flog.rb:175:in `block in flog'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/flog-4.4.0/lib/flog.rb:172:in `each'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/flog-4.4.0/lib/flog.rb:172:in `flog'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/flog-4.4.0/lib/flog_cli.rb:163:in `flog'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/metrics/flog/generator.rb:16:in `emit'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/generator.rb:104:in `generate_result'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/reporting/result.rb:48:in `add'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/run.rb:21:in `block in measure'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/run.rb:19:in `each'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/run.rb:19:in `measure'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/run.rb:9:in `run'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/cli/helper.rb:19:in `run'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/lib/metric_fu/cli/client.rb:19:in `run'
	from /my-project-root/vendor/bundle/ruby/2.3.0/gems/metric_fu-4.12.0/bin/metric_fu:9:in `<top (required)>'
	from binstubs/metric_fu:17:in `load'
	from binstubs/metric_fu:17:in `<main>'